### PR TITLE
chore(package): bump request to 2.81

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "bluebird": "~1.1.1",
     "lodash": "~2.4.1",
     "fast-stats": "~0.0.2",
-    "request": "~2.55.0"
+    "request": "~2.81.0"
   },
   "devDependencies": {
     "chai": "~1.9.1",


### PR DESCRIPTION
As the current version of request is known to be vulnerable (https://snyk.io/test/npm/promise-circuitbreaker), updating to the last version available.
Looks like tests are passing.
I'll let you bump package version and push to npmjs, assuming everything's allright. Let me know otherwise.

Thanks.