### PR TITLE
Use latest version of request

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "bluebird": "~3.5.1",
     "lodash": "~4.17.10",
     "fast-stats": "~0.0.3",
-    "request": "~2.86.0"
+    "request": "^2.88.0"
   },
   "devDependencies": {
     "chai": "~1.9.1",


### PR DESCRIPTION
This PR will update request to the latest version to avoid following CVE.

```
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ high          │ Insufficient Entropy                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ cryptiles                                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=4.1.2                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ promise-circuitbreaker                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ promise-circuitbreaker > request > hawk > cryptiles          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1464                        │
└───────────────┴──────────────────────────────────────────────────────────────┘

```